### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/hunspell-1.2.9/tests/suggestiontest/List_of_common_misspellings.txt
+++ b/hunspell-1.2.9/tests/suggestiontest/List_of_common_misspellings.txt
@@ -1,5 +1,5 @@
 # source: http://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines
-abandonned	abandoned
+abandoned	abandoned
 aberation	aberration
 abilties	abilities
 abilty	ability

--- a/hunspell-1.2.9/tests/suggestiontest/List_of_common_misspellings.txt
+++ b/hunspell-1.2.9/tests/suggestiontest/List_of_common_misspellings.txt
@@ -13,7 +13,7 @@ abreviated	abbreviated
 abreviation	abbreviation
 abritrary	arbitrary
 absense	absence
-absolutly	absolutely
+absolutely	absolutely
 absorbsion	absorption
 absorbtion	absorption
 abundacies	abundances


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
